### PR TITLE
Fixes CMakeLists.txt to properly import the paths into any location. pico-sdk compatible.

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -3,13 +3,13 @@ file(GLOB SOURCES
         "${CMAKE_CURRENT_LIST_DIR}/../src/*.cpp"
 )
 
-add_library(tcUnicodeHelper ${SOURCES})
+add_library(tcUnicodeHelper INTERFACE ${SOURCES})
 
 target_compile_definitions(IoAbstraction
-        PUBLIC BUILD_FOR_PICO_CMAKE=1 BUILD_PICO_FORCE_UART=1 IO_LOGGING_DEBUG=1
+        INTERFACE BUILD_FOR_PICO_CMAKE=1 BUILD_PICO_FORCE_UART=1 IO_LOGGING_DEBUG=1
 )
-target_include_directories(tcUnicodeHelper PUBLIC
+target_include_directories(tcUnicodeHelper INTERFACE
         ${CMAKE_CURRENT_LIST_DIR}/../src
 )
 
-target_link_libraries(tcUnicodeHelper PUBLIC pico_stdlib pico_sync IoAbstraction)
+target_link_libraries(tcUnicodeHelper INTERFACE pico_stdlib pico_sync IoAbstraction)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,13 +1,15 @@
-add_library(tcUnicodeHelper
-        ../src/tcUnicodeHelper.cpp
-        ../src/Utf8TextProcessor.cpp
+
+file(GLOB SOURCES 
+        "${CMAKE_CURRENT_LIST_DIR}/../src/*.cpp"
 )
+
+add_library(tcUnicodeHelper ${SOURCES})
 
 target_compile_definitions(IoAbstraction
         PUBLIC BUILD_FOR_PICO_CMAKE=1 BUILD_PICO_FORCE_UART=1 IO_LOGGING_DEBUG=1
 )
 target_include_directories(tcUnicodeHelper PUBLIC
-        ${PROJECT_SOURCE_DIR}/lib/tcUnicodeHelper/src
+        ${CMAKE_CURRENT_LIST_DIR}/../src
 )
 
 target_link_libraries(tcUnicodeHelper PUBLIC pico_stdlib pico_sync IoAbstraction)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,15 +1,16 @@
 
-file(GLOB SOURCES 
-        "${CMAKE_CURRENT_LIST_DIR}/../src/*.cpp"
-)
+cmake_minimum_required(VERSION 3.13)
 
-add_library(tcUnicodeHelper ${SOURCES})
+add_library(tcUnicodeHelper 
+        ../src/tcUnicodeHelper.cpp
+        ../src/Utf8TextProcessor.cpp
+)
 
 target_compile_definitions(IoAbstraction
         PUBLIC BUILD_FOR_PICO_CMAKE=1 BUILD_PICO_FORCE_UART=1 IO_LOGGING_DEBUG=1
 )
 target_include_directories(tcUnicodeHelper PUBLIC
-        ${CMAKE_CURRENT_LIST_DIR}/../src
+        ../src
 )
 
 target_link_libraries(tcUnicodeHelper PUBLIC pico_stdlib pico_sync IoAbstraction)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -3,13 +3,13 @@ file(GLOB SOURCES
         "${CMAKE_CURRENT_LIST_DIR}/../src/*.cpp"
 )
 
-add_library(tcUnicodeHelper INTERFACE ${SOURCES})
+add_library(tcUnicodeHelper ${SOURCES})
 
 target_compile_definitions(IoAbstraction
-        INTERFACE BUILD_FOR_PICO_CMAKE=1 BUILD_PICO_FORCE_UART=1 IO_LOGGING_DEBUG=1
+        PUBLIC BUILD_FOR_PICO_CMAKE=1 BUILD_PICO_FORCE_UART=1 IO_LOGGING_DEBUG=1
 )
-target_include_directories(tcUnicodeHelper INTERFACE
+target_include_directories(tcUnicodeHelper PUBLIC
         ${CMAKE_CURRENT_LIST_DIR}/../src
 )
 
-target_link_libraries(tcUnicodeHelper INTERFACE pico_stdlib pico_sync IoAbstraction)
+target_link_libraries(tcUnicodeHelper PUBLIC pico_stdlib pico_sync IoAbstraction)


### PR DESCRIPTION
In trying out the tcMenu, i found it not easy to use as the libraries had to be exported and pushed into very specific locations. Having done cmake libraries for the pico-sdk, I was able to make the required changes to properly import the sdk using cmake.

The `CMakeLists.txt` has had the paths fixed,  so that it can be used with the `libraries.cmake` that is in the `tcLibraryDev` or `FetchContent`  from cmake.

